### PR TITLE
v5 changes.

### DIFF
--- a/source/LiteDbExplorer.Core/LiteDbExplorer.Core.csproj
+++ b/source/LiteDbExplorer.Core/LiteDbExplorer.Core.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="Humanizer.Core" Version="2.7.9" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
-    <PackageReference Include="LiteDB" Version="4.1.4" />
+    <PackageReference Include="LiteDB" Version="5.0.11" />
     <PackageReference Include="PropertyChanged.Fody" Version="3.2.6" />
     <PackageReference Include="PropertyChanging.Fody" Version="1.30.0" />
     <PackageReference Include="Serilog" Version="2.9.0" />

--- a/source/LiteDbExplorer.Core/Store/CollectionReference.cs
+++ b/source/LiteDbExplorer.Core/Store/CollectionReference.cs
@@ -23,7 +23,7 @@ namespace LiteDbExplorer.Core
         [AlsoNotifyFor(nameof(LiteCollection))]
         public DatabaseReference Database { get; set; }
 
-        public LiteCollection<BsonDocument> LiteCollection => Database.LiteDatabase.GetCollection(Name);
+        public ILiteCollection<BsonDocument> LiteCollection => Database.LiteDatabase.GetCollection(Name);
 
         public ObservableCollection<DocumentReference> Items
         {
@@ -120,7 +120,7 @@ namespace LiteDbExplorer.Core
             return Items.SelectAllDistinctKeys(sortOrder).ToList();
         }
 
-        protected virtual IEnumerable<DocumentReference> GetAllItem(LiteCollection<BsonDocument> liteCollection)
+        protected virtual IEnumerable<DocumentReference> GetAllItem(ILiteCollection<BsonDocument> liteCollection)
         {
             /*if (IsFilesOrChunks)
             {

--- a/source/LiteDbExplorer.Core/Store/DocumentReference.cs
+++ b/source/LiteDbExplorer.Core/Store/DocumentReference.cs
@@ -69,12 +69,12 @@ namespace LiteDbExplorer.Core
 
         public string Serialize(bool pretty = false, bool decoded = true)
         {
-            return decoded ? LiteDocument.SerializeDecoded(true) : JsonSerializer.Serialize(LiteDocument, pretty, false);
+            return decoded ? LiteDocument.SerializeDecoded(true) : JsonSerializer.Serialize(LiteDocument);
         }
 
         public void Serialize(TextWriter writer, bool pretty = false)
         {
-            JsonSerializer.Serialize(LiteDocument, writer, pretty, false);
+            JsonSerializer.Serialize(LiteDocument, writer);
         }
     }
 }

--- a/source/LiteDbExplorer.Core/Store/DocumentReferenceAggregator.cs
+++ b/source/LiteDbExplorer.Core/Store/DocumentReferenceAggregator.cs
@@ -27,14 +27,14 @@ namespace LiteDbExplorer.Core
             }
         }
 
-        public string Serialize(bool pretty = false, bool writeBinary = true)
+        public string Serialize()
         {
-            return JsonSerializer.Serialize(Value, pretty, writeBinary);
+            return JsonSerializer.Serialize(Value);
         }
 
-        public void Serialize(TextWriter writer, bool pretty = false, bool writeBinary = true)
+        public void Serialize(TextWriter writer)
         {
-            JsonSerializer.Serialize(Value, writer, pretty, writeBinary);
+            JsonSerializer.Serialize(Value, writer);
         }
     }
 }

--- a/source/LiteDbExplorer.Core/Store/FileCollectionReference.cs
+++ b/source/LiteDbExplorer.Core/Store/FileCollectionReference.cs
@@ -10,7 +10,7 @@ namespace LiteDbExplorer.Core
         {
         }
 
-        protected override IEnumerable<DocumentReference> GetAllItem(LiteCollection<BsonDocument> liteCollection)
+        protected override IEnumerable<DocumentReference> GetAllItem(ILiteCollection<BsonDocument> liteCollection)
         {
             return LiteCollection.FindAll().Select(bsonDocument => new FileDocumentReference(bsonDocument, this));
         }
@@ -20,22 +20,8 @@ namespace LiteDbExplorer.Core
             Database.LiteDatabase.FileStorage.Delete(document.LiteDocument["_id"]);
             Items.Remove(document);
         }
-
-        public DocumentReference AddFile(string id, string path)
-        {
-            var file = Database.LiteDatabase.FileStorage.Upload(id, path);
-            var newDoc = new DocumentReference(file.AsDocument, this);
-            Items.Add(newDoc);
-            return newDoc;
-        }
-
-        public void SaveFile(DocumentReference document, string path)
-        {
-            var file = GetFileObject(document);
-            file.SaveAs(path);
-        }
-
-        public LiteFileInfo GetFileObject(DocumentReference document)
+        
+        public LiteFileInfo<string> GetFileObject(DocumentReference document)
         {
             return Database.LiteDatabase.FileStorage.FindById(document.LiteDocument["_id"]);
         }

--- a/source/LiteDbExplorer.Core/Store/FileDocumentReference.cs
+++ b/source/LiteDbExplorer.Core/Store/FileDocumentReference.cs
@@ -24,7 +24,7 @@ namespace LiteDbExplorer.Core
             file.SaveAs(path);
         }
 
-        public LiteFileInfo GetFileObject()
+        public LiteFileInfo<string> GetFileObject()
         {
             return Collection.Database.LiteDatabase.FileStorage.FindById(LiteDocument["_id"]);
         }

--- a/source/LiteDbExplorer.Core/Store/JsonSerializerExtension.cs
+++ b/source/LiteDbExplorer.Core/Store/JsonSerializerExtension.cs
@@ -7,7 +7,7 @@ namespace LiteDbExplorer.Core
 
         public static string SerializeDecoded(this BsonValue bsonValue, bool pretty = false)
         {
-            var json = JsonSerializer.Serialize(bsonValue, pretty, false);
+            var json = JsonSerializer.Serialize(bsonValue);
 
             return EncodingExtensions.DecodeEncodedNonAsciiCharacters(json);
         }

--- a/source/LiteDbExplorer.Core/Store/LiteDbReferenceExtensions.cs
+++ b/source/LiteDbExplorer.Core/Store/LiteDbReferenceExtensions.cs
@@ -96,7 +96,7 @@ namespace LiteDbExplorer.Core
                 return string.Empty;
             }
             
-            return string.Join(" - ", documentReference.Collection?.Name, documentReference.LiteDocument["_id"].AsString);
+            return string.Join(" - ", documentReference.Collection?.Name, documentReference.LiteDocument["_id"].ToString());
         }
 
         public static string ToDisplayValue(this BsonValue bsonValue, int? maxLength = null, ICultureFormat cultureFormat = null)

--- a/source/LiteDbExplorer.Core/Store/QueryResult.cs
+++ b/source/LiteDbExplorer.Core/Store/QueryResult.cs
@@ -44,11 +44,11 @@ namespace LiteDbExplorer.Core
             
             if (IsArray)
             {
-                json = JsonSerializer.Serialize(AsArray, pretty, false);
+                json = JsonSerializer.Serialize(AsArray);
             }
             else if (IsDocument)
             {
-                json = JsonSerializer.Serialize(AsDocument, pretty, false);
+                json = JsonSerializer.Serialize(AsDocument);
             }
 
             return decoded ? EncodingExtensions.DecodeEncodedNonAsciiCharacters(json) : json;
@@ -58,11 +58,11 @@ namespace LiteDbExplorer.Core
         {
             if (IsArray)
             {
-                JsonSerializer.Serialize(AsArray, writer, pretty, false);
+                JsonSerializer.Serialize(AsArray, writer);
             }
             else if (IsDocument)
             {
-                JsonSerializer.Serialize(AsDocument, writer, pretty, false);
+                JsonSerializer.Serialize(AsDocument, writer);
             }
         }
 

--- a/source/LiteDbExplorer.Core/Types/BsonValueConverter.cs
+++ b/source/LiteDbExplorer.Core/Types/BsonValueConverter.cs
@@ -14,47 +14,47 @@ namespace LiteDbExplorer.Core
                 bsonValue.Type == BsonType.Document || 
                 bsonValue.Type == BsonType.Array ||
                 bsonValue.Type == BsonType.Binary ||
-                (bsonValue.Type == BsonType.String && bsonValue.AsString.Length > 64))
+                bsonValue.Type == BsonType.String && bsonValue.AsString.Length > 64)
             {
                 return options;
             }
 
             if (bsonValue.Type != BsonType.String)
             {
-                options.Add(BsonType.String, () => new BsonValue(bsonValue.AsString));
+                options.Add(BsonType.String, () => new BsonValue(bsonValue.ToString()));
             }
 
-            if (bool.TryParse(bsonValue.AsString, out var boolResult))
+            if (bool.TryParse(bsonValue.ToString(), out var boolResult))
             {
                 options.Add(BsonType.Boolean, () => new BsonValue(boolResult));
             }
 
-            if (int.TryParse(bsonValue.AsString, out var int32Result))
+            if (int.TryParse(bsonValue.ToString(), out var int32Result))
             {
                 options.Add(BsonType.Int32, () => new BsonValue(int32Result));
             }
 
-            if (long.TryParse(bsonValue.AsString, out var int64Result))
+            if (long.TryParse(bsonValue.ToString(), out var int64Result))
             {
                 options.Add(BsonType.Int64, () => new BsonValue(int64Result));
             }
 
-            if (double.TryParse(bsonValue.AsString, out var doubleResult))
+            if (double.TryParse(bsonValue.ToString(), out var doubleResult))
             {
                 options.Add(BsonType.Double, () => new BsonValue(doubleResult));
             }
 
-            if (decimal.TryParse(bsonValue.AsString, out var decimalResult))
+            if (decimal.TryParse(bsonValue.ToString(), out var decimalResult))
             {
                 options.Add(BsonType.Decimal, () => new BsonValue(decimalResult));
             }
 
-            if (DateTime.TryParse(bsonValue.AsString, out var dateTimeResult))
+            if (DateTime.TryParse(bsonValue.ToString(), out var dateTimeResult))
             {
                 options.Add(BsonType.DateTime, () => new BsonValue(dateTimeResult));
             }
 
-            if (Guid.TryParse(bsonValue.AsString, out var guidResult))
+            if (Guid.TryParse(bsonValue.ToString(), out var guidResult))
             {
                 options.Add(BsonType.Guid, () => new BsonValue(guidResult));
             }

--- a/source/LiteDbExplorer/App.xaml.cs
+++ b/source/LiteDbExplorer/App.xaml.cs
@@ -124,7 +124,7 @@ namespace LiteDbExplorer
             var openDatabaseTask = new JumpTask
             {
                 Title = "Open database",
-                Description = "Open LiteDB v4 database file",
+                Description = "Open LiteDB v5 database file",
                 ApplicationPath = applicationPath,
                 Arguments = @"open"
             };
@@ -133,7 +133,7 @@ namespace LiteDbExplorer
             var newDatabaseTask = new JumpTask
             {
                 Title = "New database",
-                Description = "Create and open new LiteDB v4 database",
+                Description = "Create and open new LiteDB v5 database",
                 ApplicationPath = applicationPath,
                 Arguments = @"new"
             };

--- a/source/LiteDbExplorer/Controls/FileView.xaml.cs
+++ b/source/LiteDbExplorer/Controls/FileView.xaml.cs
@@ -54,7 +54,7 @@ namespace LiteDbExplorer.Controls
         private static void OnFileSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var fileView = d as FileView;
-            if (e.NewValue is LiteFileInfo liteFileInfo)
+            if (e.NewValue is LiteFileInfo<string> liteFileInfo)
             {
                 fileView?.LoadFile(liteFileInfo);
             }
@@ -92,7 +92,7 @@ namespace LiteDbExplorer.Controls
 
         public string FileExtension { get; private set; }
 
-        public void LoadFile(LiteFileInfo file)
+        public void LoadFile(LiteFileInfo<string> file)
         {
             Reset();
 
@@ -153,7 +153,7 @@ namespace LiteDbExplorer.Controls
             NoFilePreviewText.Text = string.Empty;
         }
 
-        protected void SetNoContentPreview(LiteFileInfo file, string prependMessage = null)
+        protected void SetNoContentPreview(LiteFileInfo<string> file, string prependMessage = null)
         {
             var message = $"No preview for \"{file.MimeType}\".";
             if (!string.IsNullOrEmpty(prependMessage))
@@ -177,7 +177,7 @@ namespace LiteDbExplorer.Controls
             ResetNoContentPreview();
         }
 
-        protected void SetFileInfoContent(LiteFileInfo file)
+        protected void SetFileInfoContent(LiteFileInfo<string> file)
         {
             var fileInfo = new Dictionary<string, string>
             {
@@ -245,20 +245,20 @@ namespace LiteDbExplorer.Controls
     public abstract class FilePreviewHandler
     {
         public abstract bool CanContentScroll { get; }
-        public abstract bool CanHandle(LiteFileInfo file);
-        public abstract FrameworkElement GetPreview(LiteFileInfo file);
+        public abstract bool CanHandle(LiteFileInfo<string> file);
+        public abstract FrameworkElement GetPreview(LiteFileInfo<string> file);
     }
 
     public class ImageFilePreviewHandler : FilePreviewHandler
     {
         public override bool CanContentScroll => false;
 
-        public override bool CanHandle(LiteFileInfo file)
+        public override bool CanHandle(LiteFileInfo<string> file)
         {
             return file.MimeType.StartsWith("image");
         }
 
-        public override FrameworkElement GetPreview(LiteFileInfo file)
+        public override FrameworkElement GetPreview(LiteFileInfo<string> file)
         {
             using (var fStream = file.OpenRead())
             {
@@ -308,13 +308,13 @@ namespace LiteDbExplorer.Controls
             }
         }
 
-        public override bool CanHandle(LiteFileInfo file)
+        public override bool CanHandle(LiteFileInfo<string> file)
         {
             var fileExtension = Path.GetExtension(file.Filename);
             return TextRegex.IsMatch(file.MimeType) || _allHandledTextExtension.Contains(fileExtension);
         }
 
-        public override FrameworkElement GetPreview(LiteFileInfo file)
+        public override FrameworkElement GetPreview(LiteFileInfo<string> file)
         {
             var fileExtension = Path.GetExtension(file.Filename);
             using (var fileStream = file.OpenRead())

--- a/source/LiteDbExplorer/LiteDbExplorer.csproj
+++ b/source/LiteDbExplorer/LiteDbExplorer.csproj
@@ -598,7 +598,7 @@
       <Version>2019.1.3</Version>
     </PackageReference>
     <PackageReference Include="LiteDB">
-      <Version>4.1.4</Version>
+      <Version>5.0.11</Version>
     </PackageReference>
     <PackageReference Include="Markdig">
       <Version>0.18.0</Version>

--- a/source/LiteDbExplorer/Modules/Database/DatabasePropertiesViewModel.cs
+++ b/source/LiteDbExplorer/Modules/Database/DatabasePropertiesViewModel.cs
@@ -137,7 +137,7 @@ namespace LiteDbExplorer.Modules.Database
 
             DatabaseFileInfo = databaseFileInfo;
 
-            MetadataJson = JsonSerializer.Serialize(engineInfoDocument, true, false);
+            MetadataJson = JsonSerializer.Serialize(engineInfoDocument);
         }
 
     }

--- a/source/LiteDbExplorer/Modules/DatabaseInteractions.cs
+++ b/source/LiteDbExplorer/Modules/DatabaseInteractions.cs
@@ -15,6 +15,7 @@ using Enterwell.Clients.Wpf.Notifications;
 using Forge.Forms;
 using LiteDbExplorer.Core;
 using LiteDB;
+using LiteDB.Engine;
 using LiteDbExplorer.Modules.Shared;
 using LiteDbExplorer.Presentation;
 using OfficeOpenXml;
@@ -84,7 +85,7 @@ namespace LiteDbExplorer.Modules
 
             using (var stream = new FileStream(maybeFileName.Value, System.IO.FileMode.Create))
             {
-                LiteEngine.CreateDatabase(stream);
+                new LiteDatabase(stream);
             }
 
             await OpenDatabase(maybeFileName.Value).ConfigureAwait(false);
@@ -191,7 +192,7 @@ namespace LiteDbExplorer.Modules
 
         protected virtual async Task OpenDatabaseExceptionHandler(LiteException liteException, string path, string password = "")
         {
-            if (liteException.ErrorCode == LiteException.DATABASE_WRONG_PASSWORD)
+            if (liteException.Message == "Invalid password")
             {
                 if (!string.IsNullOrEmpty(password))
                 {
@@ -524,7 +525,7 @@ namespace LiteDbExplorer.Modules
         {
             var documentAggregator = new DocumentReferenceAggregator(documents);
             
-            Clipboard.SetData(DataFormats.Text, documentAggregator.Serialize(true, false));
+            Clipboard.SetData(DataFormats.Text, documentAggregator.Serialize());
 
             return Task.FromResult(Result.Ok());
         }
@@ -626,7 +627,7 @@ namespace LiteDbExplorer.Modules
                     var documentAggregator = new DocumentReferenceAggregator(documents);
                     using (var writer = new StreamWriter(maybeJsonFileName.Value))
                     {
-                        documentAggregator.Serialize(writer, true, false);
+                        documentAggregator.Serialize(writer);
                     }
                 }
             }

--- a/source/LiteDbExplorer/Modules/DbDocument/DocumentPreviewViewModel.cs
+++ b/source/LiteDbExplorer/Modules/DbDocument/DocumentPreviewViewModel.cs
@@ -56,7 +56,7 @@ namespace LiteDbExplorer.Modules.DbDocument
             }
         }
         
-        public LiteFileInfo FileInfo { get; private set; }
+        public LiteFileInfo<string> FileInfo { get; private set; }
 
         public bool IsDocumentView { get; private set; }
 

--- a/source/LiteDbExplorer/Modules/Shared/AddDocumentOptions.cs
+++ b/source/LiteDbExplorer/Modules/Shared/AddDocumentOptions.cs
@@ -91,7 +91,7 @@ namespace LiteDbExplorer.Modules.Shared
             _newIdLookup.IdType = IdType;
             NewId = _newIdLookup.NewId;
             IdIsValid = true;
-            _newIdString = NewId.AsString;
+            _newIdString = NewId.ToString();
             OnPropertyChanged(nameof(NewIdString));
         }
 

--- a/source/LiteDbExplorer/Modules/StartPage/StartPage.xaml
+++ b/source/LiteDbExplorer/Modules/StartPage/StartPage.xaml
@@ -338,7 +338,7 @@
                                        TextTrimming="CharacterEllipsis"
                                        Style="{StaticResource MaterialDesignSubheadingTextBlock}" />
                             <TextBlock Grid.Column="1" Grid.Row="1"
-                                       Text="Open LiteDB v4 database file" Padding="0,5"
+                                       Text="Open LiteDB v5 database file" Padding="0,5"
                                        TextWrapping="Wrap"
                                        Style="{StaticResource MaterialDesignCaptionTextBlock}" />
                         </Grid>
@@ -361,7 +361,7 @@
                                        TextTrimming="CharacterEllipsis"
                                        Style="{StaticResource MaterialDesignSubheadingTextBlock}" />
                             <TextBlock Grid.Column="1" Grid.Row="1"
-                                       Text="Create and open new LiteDB v4 database" Padding="0,5"
+                                       Text="Create and open new LiteDB v5 database" Padding="0,5"
                                        TextWrapping="Wrap"
                                        Style="{StaticResource MaterialDesignCaptionTextBlock}" />
                         </Grid>


### PR DESCRIPTION
This is my first time creating a pull request and contributing to a public project so please bare with me here. But I made LiteDbExplorer work with LiteDB v5 and wanted to share this with you. I really like your explorer because it's stylish and includes a dark theme compared to the "ugly" LiteDB.Studio.
Besides the obvious I've had to change a lot of `BsonValue.AsString` calls to` ToString()` since they would keep throwing `InvalidCastException`'s. I don't know if there was a fundamental change in LiteDB that causes this but with these changes it works for me. Since the `LiteException`'s error codes seem to have changed to I had to add some hardcoded string like `"This data file is encrypted and needs a password to open"` as the `ErrorCode` property is `0` when it fails. You might want to change that to `const`? I've removed the `AddFile` and `SaveFile` methods from `FileCollectionReference.cs` since they where not referenced anywhere.

I've tested creating/opening databases (with and without password), adding/editing tables and uploading/exporting files.

Hope this helps.